### PR TITLE
fix --name missing

### DIFF
--- a/dev_scripts/dtu_test_inf/inftest_scan1.sh
+++ b/dev_scripts/dtu_test_inf/inftest_scan1.sh
@@ -148,7 +148,7 @@ split="train"
 cd run
 
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/dtu_test_inf/inftest_scan103.sh
+++ b/dev_scripts/dtu_test_inf/inftest_scan103.sh
@@ -142,7 +142,7 @@ split="train"
 cd run
 
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/dtu_test_inf/inftest_scan114.sh
+++ b/dev_scripts/dtu_test_inf/inftest_scan114.sh
@@ -144,7 +144,7 @@ split="train"
 cd run
 
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/dtu_test_inf/inftest_scan21.sh
+++ b/dev_scripts/dtu_test_inf/inftest_scan21.sh
@@ -143,7 +143,7 @@ split="train"
 cd run
 
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/dtu_test_inf/inftest_scan8.sh
+++ b/dev_scripts/dtu_test_inf/inftest_scan8.sh
@@ -144,7 +144,7 @@ split="train"
 cd run
 
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/ete/dtu_dgt_d012_img0123_conf_agg2_32_dirclr20.sh
+++ b/dev_scripts/ete/dtu_dgt_d012_img0123_conf_agg2_32_dirclr20.sh
@@ -123,7 +123,7 @@ split="train"
 
 cd run
 python3 train.py \
-        --name $name \
+        --experiment $name \
         --data_root $data_root \
         --dataset_name $dataset_name \
         --model $model \

--- a/dev_scripts/ete/dtu_dgt_d012_img0123_conf_color_dir_agg2.sh
+++ b/dev_scripts/ete/dtu_dgt_d012_img0123_conf_color_dir_agg2.sh
@@ -127,7 +127,7 @@ split="train"
 
 cd run
 python3 train.py \
-        --name $name \
+        --experiment $name \
         --data_root $data_root \
         --dataset_name $dataset_name \
         --model $model \

--- a/dev_scripts/w_colmap_n360/col_chair.sh
+++ b/dev_scripts/w_colmap_n360/col_chair.sh
@@ -154,7 +154,7 @@ for i in $(seq 1 $prob_freq $maximum_step)
 do
 #python3 gen_pnts.py \
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_colmap_n360/col_drums.sh
+++ b/dev_scripts/w_colmap_n360/col_drums.sh
@@ -158,7 +158,7 @@ for i in $(seq 1 $prob_freq $maximum_step)
 
 do
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_colmap_n360/col_ficus.sh
+++ b/dev_scripts/w_colmap_n360/col_ficus.sh
@@ -159,7 +159,7 @@ for i in $(seq 1 $prob_freq $maximum_step)
 do
 #python3 gen_pnts.py \
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_colmap_n360/col_hotdog.sh
+++ b/dev_scripts/w_colmap_n360/col_hotdog.sh
@@ -161,7 +161,7 @@ for i in $(seq 1 $prob_freq $maximum_step)
 do
 #python3 gen_pnts.py \
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_colmap_n360/col_lego.sh
+++ b/dev_scripts/w_colmap_n360/col_lego.sh
@@ -159,7 +159,7 @@ for i in $(seq 1 $prob_freq $maximum_step)
 
 do
 python3 train_ft.py \
-       --name $name \
+       --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_colmap_n360/col_materials.sh
+++ b/dev_scripts/w_colmap_n360/col_materials.sh
@@ -158,7 +158,7 @@ for i in $(seq 1 $prob_freq $maximum_step)
 
 do
 python3 train_ft.py \
-       --name $name \
+       --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_colmap_n360/col_mic.sh
+++ b/dev_scripts/w_colmap_n360/col_mic.sh
@@ -162,7 +162,7 @@ for i in $(seq 1 $prob_freq $maximum_step)
 do
 #python3 gen_pnts.py \
 python3 train_ft.py \
-       --name $name \
+       --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_colmap_n360/col_ship.sh
+++ b/dev_scripts/w_colmap_n360/col_ship.sh
@@ -163,7 +163,7 @@ for i in $(seq 1 $prob_freq $maximum_step)
 do
 
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_n360/chair.sh
+++ b/dev_scripts/w_n360/chair.sh
@@ -164,7 +164,7 @@ for i in $(seq 1 $prob_freq $maximum_step)
 do
 #python3 gen_pnts.py \
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_n360/chair_test.sh
+++ b/dev_scripts/w_n360/chair_test.sh
@@ -99,7 +99,7 @@ split="train"
 cd run
 
 python3 test_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_n360/drums.sh
+++ b/dev_scripts/w_n360/drums.sh
@@ -166,7 +166,7 @@ for i in $(seq 1 $prob_freq $maximum_step)
 do
 
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_n360/drums_test.sh
+++ b/dev_scripts/w_n360/drums_test.sh
@@ -103,7 +103,7 @@ cd run
 
 
 python3 test_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_n360/ficus.sh
+++ b/dev_scripts/w_n360/ficus.sh
@@ -164,7 +164,7 @@ cd run
 
 #python3 gen_pnts.py \
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_n360/ficus_test.sh
+++ b/dev_scripts/w_n360/ficus_test.sh
@@ -97,7 +97,7 @@ split="train"
 cd run
 
 python3 test_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_n360/hotdog.sh
+++ b/dev_scripts/w_n360/hotdog.sh
@@ -162,7 +162,7 @@ for i in $(seq 1 $prob_freq $maximum_step)
 do
 #python3 gen_pnts.py \
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_n360/hotdog_test.sh
+++ b/dev_scripts/w_n360/hotdog_test.sh
@@ -99,7 +99,7 @@ split="train"
 cd run
 
 python3 test_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_n360/lego.sh
+++ b/dev_scripts/w_n360/lego.sh
@@ -165,7 +165,7 @@ for i in $(seq 1 $prob_freq $maximum_step)
 do
 #python3 gen_pnts.py \
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_n360/lego_test.sh
+++ b/dev_scripts/w_n360/lego_test.sh
@@ -100,7 +100,7 @@ split="train"
 cd run
 
 python3 test_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_n360/materials.sh
+++ b/dev_scripts/w_n360/materials.sh
@@ -166,7 +166,7 @@ for i in $(seq 1 $prob_freq $maximum_step)
 do
 
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_n360/materials_test.sh
+++ b/dev_scripts/w_n360/materials_test.sh
@@ -101,7 +101,7 @@ split="train"
 cd run
 
 python3 test_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_n360/mic.sh
+++ b/dev_scripts/w_n360/mic.sh
@@ -160,7 +160,7 @@ split="train"
 cd run
 
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_n360/mic_test.sh
+++ b/dev_scripts/w_n360/mic_test.sh
@@ -97,7 +97,7 @@ split="train"
 cd run
 
 python3 test_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_n360/ship.sh
+++ b/dev_scripts/w_n360/ship.sh
@@ -165,7 +165,7 @@ for i in $(seq 1 $prob_freq $maximum_step)
 do
 #python3 gen_pnts.py \
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_n360/ship_all.sh
+++ b/dev_scripts/w_n360/ship_all.sh
@@ -167,7 +167,7 @@ cd run
 
 
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_n360/ship_all_test.sh
+++ b/dev_scripts/w_n360/ship_all_test.sh
@@ -99,7 +99,7 @@ cd run
 
 
 python3 test_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_n360/ship_test.sh
+++ b/dev_scripts/w_n360/ship_test.sh
@@ -98,7 +98,7 @@ split="train"
 cd run
 
 python3 test_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_scannet_etf/scene101.sh
+++ b/dev_scripts/w_scannet_etf/scene101.sh
@@ -99,7 +99,7 @@ split="train"
 cd run
 
 python3 test_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_scannet_etf/scene101_test.sh
+++ b/dev_scripts/w_scannet_etf/scene101_test.sh
@@ -95,7 +95,7 @@ split="train"
 cd run
 
 python3 test_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_scannet_etf/scene241.sh
+++ b/dev_scripts/w_scannet_etf/scene241.sh
@@ -163,7 +163,7 @@ for i in $(seq 1 $prob_freq $maximum_step)
 do
 
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_scannet_etf/scene241_test.sh
+++ b/dev_scripts/w_scannet_etf/scene241_test.sh
@@ -108,7 +108,7 @@ split="train"
 cd run
 
 python3 test_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_tt_ft/barn.sh
+++ b/dev_scripts/w_tt_ft/barn.sh
@@ -165,7 +165,7 @@ for i in $(seq 1 $prob_freq $maximum_step)
 
 do
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_tt_ft/barn_test.sh
+++ b/dev_scripts/w_tt_ft/barn_test.sh
@@ -95,7 +95,7 @@ split="train"
 cd run
 
 python3 test_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_tt_ft/caterpillar.sh
+++ b/dev_scripts/w_tt_ft/caterpillar.sh
@@ -164,7 +164,7 @@ for i in $(seq 1 $prob_freq $maximum_step)
 do
 
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_tt_ft/caterpillar_test.sh
+++ b/dev_scripts/w_tt_ft/caterpillar_test.sh
@@ -93,7 +93,7 @@ split="train"
 cd run
 
 python3 test_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_tt_ft/family.sh
+++ b/dev_scripts/w_tt_ft/family.sh
@@ -162,7 +162,7 @@ for i in $(seq 1 $prob_freq $maximum_step)
 
 do
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_tt_ft/family_test.sh
+++ b/dev_scripts/w_tt_ft/family_test.sh
@@ -95,7 +95,7 @@ split="train"
 cd run
 
 python3 test_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_tt_ft/ignatius.sh
+++ b/dev_scripts/w_tt_ft/ignatius.sh
@@ -161,7 +161,7 @@ for i in $(seq 1 $prob_freq $maximum_step)
 do
 #python3 gen_pnts.py \
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_tt_ft/ignatius_test.sh
+++ b/dev_scripts/w_tt_ft/ignatius_test.sh
@@ -98,7 +98,7 @@ split="train"
 cd run
 
 python3 test_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_tt_ft/truck.sh
+++ b/dev_scripts/w_tt_ft/truck.sh
@@ -160,7 +160,7 @@ for i in $(seq 1 $prob_freq $maximum_step)
 
 do
 python3 train_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/dev_scripts/w_tt_ft/truck_test.sh
+++ b/dev_scripts/w_tt_ft/truck_test.sh
@@ -95,7 +95,7 @@ split="train"
 cd run
 
 python3 test_ft.py \
-        --name $name \
+        --experiment $name \
         --scan $scan \
         --data_root $data_root \
         --dataset_name $dataset_name \

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -8,9 +8,10 @@ import torch
 class BaseOptions:
     def initialize(self, parser: argparse.ArgumentParser):
         #================================ global ================================#
-        parser.add_argument('--name',
+        parser.add_argument('--experiment',
                             type=str,
                             required=True,
+                            dest='name',
                             help='name of the experiment')
         parser.add_argument(
             '--verbose',


### PR DESCRIPTION
It looks like there is a bug in matplotlib: it removes the --name argument from sys.argv on import in the latest version. I reported this bug to matplotlib (https://github.com/matplotlib/matplotlib/issues/23236). Meanwhile, I think it would be a good idea to rename this flag to something else.

Fixes #27 